### PR TITLE
Properly parse transactions with IDs having a hex representation that starts with 0

### DIFF
--- a/src/liteClientProvider.ts
+++ b/src/liteClientProvider.ts
@@ -28,6 +28,7 @@ import { Maybe } from '@ton/core/dist/utils/maybe';
 import { LiteClient } from './'
 import { tonNode_BlockIdExt } from './schema'
 import { Buffer } from "buffer";
+import { txHashToBuffer } from './utils/bigint';
 
 export function createLiteClientProvider(
     client: LiteClient,
@@ -58,7 +59,7 @@ export function createLiteClientProvider(
             const last = state.lastTx // .account.last
                 ? {
                     lt: BigInt(state.lastTx.lt),
-                    hash: Buffer.from(state.lastTx.hash.toString(16), 'hex'),
+                    hash: txHashToBuffer(state.lastTx.hash),
                 }
                 : null
             let storage:
@@ -89,7 +90,7 @@ export function createLiteClientProvider(
             } else if (state.state?.storage.state.type === 'frozen') {
                 storage = {
                     type: 'frozen',
-                    stateHash: Buffer.from(state.state.storage.state.stateHash.toString(16), 'hex'),
+                    stateHash: txHashToBuffer(state.state.storage.state.stateHash),
                 }
             } else {
                 throw Error('Unsupported state')

--- a/src/utils/bigint.ts
+++ b/src/utils/bigint.ts
@@ -1,0 +1,32 @@
+import { Buffer } from "buffer";
+
+export function txHashToBuffer(hash: bigint) {
+    return bigIntToBuffer(hash, 32)
+}
+
+function bigIntToBuffer(bigint: bigint, byteLength?: number) {
+    return Buffer.from(bigIntToHex(bigint, byteLength), 'hex')
+}
+
+function bigIntToHex(bigint: bigint, byteLength?: number) {
+    if (bigint < 0) {
+        throw new TypeError("Negative values are not supported")
+    }
+    if (byteLength !== undefined && byteLength <= 0) {
+        throw new TypeError("Invalid byte length")
+    }
+
+    const hex = bigint.toString(16)
+    if (byteLength === undefined) {
+        return hex.length % 2 ? `0${hex}` : hex
+    }
+
+    const maxValue = (1n << BigInt(byteLength * 8)) - 1n
+    if (bigint > maxValue) {
+        throw new TypeError(
+            `Value exceeds the maximum for ${byteLength} bytes`
+        )
+    }
+
+    return hex.padStart(byteLength * 2, '0')
+}


### PR DESCRIPTION
```ts
// Some transaction hash
const bigint = 6670824317315775044312753864173510730808811828017716924709329703051298687774n;
const hex = bigint.toString(16); // ebf8d81e12240e0a0ba39ae08f1186949ff84d03a8ea3165ac02f6a7b794b1e
// correct version for Buffer.from: 0ebf8d81e12240e0a0ba39ae08f1186949ff84d03a8ea3165ac02f6a7b794b1e

const buffer = Buffer.from(hex, "hex"); // eb f8 d8 1e 12 24 0e 0a 0b a3 9a e0 8f 11 86 94 9f f8 4d 03 a8 ea 31 65 ac 02 f6 a7 b7 94 b1 (31 bytes, expected 32)
```

`BigInt.prototype.toString` omits preceding zeros in the returned hex representations, and `Buffer.from(hex, "hex")` will ignore the first and last hex digits, corrupting transaction IDs having a hex representation that starts with 0.

This PR fixes that.
